### PR TITLE
Add image megapixel value in the title

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -15,7 +15,7 @@
 // @grant       GM_openInTab
 // @grant       GM_registerMenuCommand
 
-// @version     1.0.15
+// @version     1.0.14
 // @author      tophf
 
 // @original-version 2017.9.29
@@ -565,7 +565,7 @@ class App {
   static updateTitle() {
     if (!ai.bar)
       return;
-    const megapixels = Math.round(100 * (ai.nwidth * ai.nheight / 1000000)) / 100;
+    const megapixels = Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100;
     const zoom = `${Math.round(ai.scale * 100)}% - ${ai.nwidth} x ${ai.nheight} px - ${megapixels} MP`;
     if (ai.bar.dataset.zoom !== zoom) {
       ai.bar.dataset.zoom = zoom;

--- a/script.user.js
+++ b/script.user.js
@@ -15,7 +15,7 @@
 // @grant       GM_openInTab
 // @grant       GM_registerMenuCommand
 
-// @version     1.0.14
+// @version     1.0.15
 // @author      tophf
 
 // @original-version 2017.9.29
@@ -565,7 +565,8 @@ class App {
   static updateTitle() {
     if (!ai.bar)
       return;
-    const zoom = `${Math.round(ai.scale * 100)}% - ${ai.nwidth} x ${ai.nheight} px`;
+    const megapixels = Math.round(100 * (ai.nwidth * ai.nheight / 1000000)) / 100;
+    const zoom = `${Math.round(ai.scale * 100)}% - ${ai.nwidth} x ${ai.nheight} px - ${megapixels} MP`;
     if (ai.bar.dataset.zoom !== zoom) {
       ai.bar.dataset.zoom = zoom;
       App.updateBar();


### PR DESCRIPTION
This is a suggestion I had made to the original script ([link](https://greasyfork.org/en/forum/discussion/11683/x)). 

For reference:
> 1 Megapixel = 1,000,000 pixels
> How to find the megapixel value: 
> multiply the resolution of the image (width * height) then divide by 1,000,000.

In my PR the MP value is rounded to 2 decimal places at most.

Example comparison:
Before:
![](https://user-images.githubusercontent.com/723651/73289865-15ba7680-4206-11ea-8257-e1ecf272fed1.jpg)
After:
![](https://user-images.githubusercontent.com/723651/73289940-384c8f80-4206-11ea-842e-d87291154aad.jpg)

I believe that the megapixel value is useful info: it helps easily perceive whether (and how much) the size of an image is larger than another.


I hope you like my suggestion.

P.S. Thank you for continuing this great usercript!