### PR TITLE
twitter media rule: display maximum resolution

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1798,7 +1798,7 @@ const Ruler = {
       {
         u: '||twimg.com/media/',
         r: /.+?format=(jpe?g|png|gif)/i,
-        s: '$0&name=4096x4096',
+        s: '$0&name=orig',
       },
       {
         u: '||twimg.com/1/proxy',

--- a/script.user.js
+++ b/script.user.js
@@ -1798,7 +1798,7 @@ const Ruler = {
       {
         u: '||twimg.com/media/',
         r: /.+?format=(jpe?g|png|gif)/i,
-        s: '$0&name=large',
+        s: '$0&name=4096x4096',
       },
       {
         u: '||twimg.com/1/proxy',


### PR DESCRIPTION
With this change, it displays the maximum possible resolution in all cases (and, it doesn't cause problem in images of lower resolution)

This pattern `4096x4096` is the URLs if you open such expanded tweet image in a new tab.
e.g. open https://twitter.com/instagram/status/1285626460552728583
click on the image to expand, and then right click on the image|"Open image in new tab":
https://pbs.twimg.com/media/Edd1gYPU0AAjyLy?format=jpg&name=4096x4096  (4096x2659)

_vs https://pbs.twimg.com/media/Edd1gYPU0AAjyLy?format=jpg&name=large (2048x1330)_

Thank you

