### PR TITLE
Remove upix.me rule (no longer working domain)

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1810,10 +1810,6 @@ const Ruler = {
         s: 'https://twitpic.com/show/large/$2',
       },
       {
-        u: '||upix.me/files',
-        s: '/#//',
-      },
-      {
         u: '||wiki',
         r: /\/(thumb|images)\/.+\.(jpe?g|gif|png|svg)\/(revision\/)?/i,
         s: '/\\/thumb(?=\\/)|' +


### PR DESCRIPTION
I've noticed that the upix.me domain no longer works,
and such links sometimes redirect to ad/spam pages.