### PR TITLE
Add keyboard shortcuts for image zoom (fixes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Action | Trigger
 **Force-activate<br>(for small pics)** | hold <code>Ctrl</code> while entering image element
 &nbsp; |
 **Start zooming** | configurable: automatic or via right-click / <code>Shift</code> while popup is visible
-**Zoom** | mouse wheel
+**Zoom** | mouse wheel / <code>-</code> <code>=</code> keys (minus or equals)
 **Rotate** | <code>L</code> <code>r</code> keys (left or right)
 **Flip/mirror** | <code>h</code> <code>v</code> keys (horizontally or vertically)
 **Previous/next in album** | mouse wheel, <code>j</code> <code>k</code> or <code>←</code> <code>→</code> keys

--- a/script.user.js
+++ b/script.user.js
@@ -850,6 +850,20 @@ const Events = {
         GM_openInTab(Util.tabFixUrl() || p.src);
         App.deactivate();
         break;
+      case 'Minus':
+        if (ai.zoomed) {
+          Events.zoomInOut(-1);
+        } else {
+          App.toggleZoom();
+        }
+        break;
+      case 'Equal':
+        if (ai.zoomed) {
+          Events.zoomInOut(1);
+        } else {
+          App.toggleZoom();
+        }
+        break;
       case 'Escape':
         App.deactivate({wait: true});
         break;


### PR DESCRIPTION
`Minus` and `Equals` added as shortcut keys for decreasing/increasing zoom. Updated table in readme to reflect changes.