### PR TITLE
Fix for Instagram timeline posts

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1723,7 +1723,7 @@ const Ruler = {
           '||instagr.am/p/',
           '||instagram.com/p/',
         ],
-        s: m => m.input.substr(0, m.input.lastIndexOf('/')) + '/?__a=1',
+        s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by','') + '/?__a=1',
         q: text => {
           const m = JSON.parse(text).graphql.shortcode_media;
           return m.video_url || m.display_url;


### PR DESCRIPTION
Instagram recently changed the HTML,
and so, hovering on a post in your timeline (https://www.instagram.com/ after login),
results in the URL in "m" (match) having `liked_by/` to its end: e.g.  
`https://www.instagram.com/p/CK1ofvvDqAn/liked_by/` instead of 
`https://www.instagram.com/p/CK1ofvvDqAn/` ,
and so the built-in rule doesn't work ( "Unexpected token < in JSON at position 1" ) because
`https://www.instagram.com/p/CK1ofvvDqAn/liked_by/?__a=1` just redirects to the post URL, instead of being JSON.

This PR fixes this by removing `/liked_by`.
