### PR TITLE
Auto-activate on hovered image at `load` event

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -3786,7 +3786,7 @@ Config.load({save: true}).then(res => {
       const hovered = [...$$(':hover')].pop();
       if (hovered)
         Events.triggerHover(hovered);
-      }, {once: true});
+    }, {once: true});
   }
 });
 

--- a/script.user.js
+++ b/script.user.js
@@ -3783,10 +3783,10 @@ Config.load({save: true}).then(res => {
   window.addEventListener('message', App.onMessage);
   if (cfg.autoactivateAtLoad) {
     window.addEventListener('load', () => {
-    const hovered = [...$$(':hover')].pop();
-    if (hovered)
-      Events.triggerHover(hovered);
-    }, {once: true});
+      const hovered = [...$$(':hover')].pop();
+      if (hovered)
+        Events.triggerHover(hovered);
+      }, {once: true});
   }
 });
 


### PR DESCRIPTION
Implements #34 

Re-add https://github.com/tophf/mpiv/commit/a7cb177d887c119a9fde950692bd827b4ec9bd47 via its own setting disabled by default

If you agree to merge, I'll also add a wiki entry that: 

> The new setting `Auto-activate on hovered image at load event`
> is currently aimed for Firefox users only (there's a bug in Chrome, see: https://crbug.com/307375)

