### PR TITLE
Add image aspect ratio in the title

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -452,7 +452,7 @@ const Bar = {
     } px, ${
       Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100
     } MP, ${
-      aspectRatio(ai.nwidth / ai.nheight, 20)
+      aspectRatio(ai.nwidth, ai.nheight)
     }`.replace(/\x20/g, '\xA0');
     if (ai.bar.dataset.zoom !== zoom || !ai.nwidth) {
       if (zoom) ai.bar.dataset.zoom = zoom;
@@ -462,37 +462,17 @@ const Bar = {
   },
 };
 
-// https://stackoverflow.com/a/43016456/3231411
-function aspectRatio(val, lim) {
-
-  let lower = [0, 1];
-  let upper = [1, 0];
-
-  while (true) {
-    const mediant = [lower[0] + upper[0], lower[1] + upper[1]];
-
-    if (val * mediant[1] > mediant[0]) {
-      if (lim < mediant[1]) {
-        return upper.join(':');
-      }
-      lower = mediant;
-    } else if (val * mediant[1] === mediant[0]) {
-      if (lim >= mediant[1]) {
-        return mediant.join(':');
-      }
-      if (lower[1] < upper[1]) {
-        return lower.join(':');
-      }
-      return upper.join(':');
-    } else {
-      if (lim < mediant[1]) {
-        return lower.join(':');
-      }
-      upper = mediant;
-    }
+function aspectRatio(w, h) {
+  for (let err, rat = w / h, a, b = 0; ;) {
+    b++;
+    a = Math.round(w * b / h);
+    if (a > 20 || b > 20)
+      return rat.toFixed(2);
+    err = Math.abs(a / b - rat);
+    if (err < 1e-3)
+      return `${a}:${b}`;
   }
 }
-
 
 const Calc = {
 

--- a/script.user.js
+++ b/script.user.js
@@ -452,7 +452,7 @@ const Bar = {
     } px, ${
       Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100
     } MP, ${
-      aspectRatio(ai.nwidth/ai.nheight, 50)
+      aspectRatio(ai.nwidth/ai.nheight, 20)
     }`.replace(/\x20/g, '\xA0');
     if (ai.bar.dataset.zoom !== zoom || !ai.nwidth) {
       if (zoom) ai.bar.dataset.zoom = zoom;

--- a/script.user.js
+++ b/script.user.js
@@ -452,7 +452,7 @@ const Bar = {
     } px, ${
       Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100
     } MP, ${
-      aspectRatio(ai.nwidth, ai.nheight)
+      Calc.aspectRatio(ai.nwidth, ai.nheight)
     }`.replace(/\x20/g, '\xA0');
     if (ai.bar.dataset.zoom !== zoom || !ai.nwidth) {
       if (zoom) ai.bar.dataset.zoom = zoom;
@@ -462,19 +462,18 @@ const Bar = {
   },
 };
 
-function aspectRatio(w, h) {
-  for (let err, rat = w / h, a, b = 0; ;) {
-    b++;
-    a = Math.round(w * b / h);
-    if (a > 20 || b > 20)
-      return rat.toFixed(2);
-    err = Math.abs(a / b - rat);
-    if (err < 1e-3)
-      return `${a}:${b}`;
-  }
-}
-
 const Calc = {
+
+  aspectRatio(w, h) {
+    for (let rat = w / h, a, b = 0; ;) {
+      b++;
+      a = Math.round(w * b / h);
+      if (a > 10 && b > 10 || a > 100 || b > 100)
+        return rat.toFixed(2);
+      if (Math.abs(a / b - rat) < .01)
+        return `${a}:${b}`;
+    }
+  },
 
   frameSize(elFrame, parentWindow) {
     if (!elFrame) return;

--- a/script.user.js
+++ b/script.user.js
@@ -452,7 +452,7 @@ const Bar = {
     } px, ${
       Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100
     } MP, ${
-      aspectRatio(ai.nwidth/ai.nheight, 20)
+      aspectRatio(ai.nwidth / ai.nheight, 20)
     }`.replace(/\x20/g, '\xA0');
     if (ai.bar.dataset.zoom !== zoom || !ai.nwidth) {
       if (zoom) ai.bar.dataset.zoom = zoom;

--- a/script.user.js
+++ b/script.user.js
@@ -451,7 +451,9 @@ const Bar = {
       ai.nheight
     } px, ${
       Math.round(100 * (ai.nwidth * ai.nheight / 1e6)) / 100
-    } MP`.replace(/\x20/g, '\xA0');
+    } MP, ${
+      aspectRatio(ai.nwidth/ai.nheight, 50)
+    }`.replace(/\x20/g, '\xA0');
     if (ai.bar.dataset.zoom !== zoom || !ai.nwidth) {
       if (zoom) ai.bar.dataset.zoom = zoom;
       else delete ai.bar.dataset.zoom;
@@ -459,6 +461,38 @@ const Bar = {
     }
   },
 };
+
+// https://stackoverflow.com/a/43016456/3231411
+function aspectRatio(val, lim) {
+
+  let lower = [0, 1];
+  let upper = [1, 0];
+
+  while (true) {
+    const mediant = [lower[0] + upper[0], lower[1] + upper[1]];
+
+    if (val * mediant[1] > mediant[0]) {
+      if (lim < mediant[1]) {
+        return upper.join(':');
+      }
+      lower = mediant;
+    } else if (val * mediant[1] === mediant[0]) {
+      if (lim >= mediant[1]) {
+        return mediant.join(':');
+      }
+      if (lower[1] < upper[1]) {
+        return lower.join(':');
+      }
+      return upper.join(':');
+    } else {
+      if (lim < mediant[1]) {
+        return lower.join(':');
+      }
+      upper = mediant;
+    }
+  }
+}
+
 
 const Calc = {
 


### PR DESCRIPTION
Greetings @tophf 

I'd like to make an addition to my old PR #2 ('image megapixel value in the title'):
i.e. to add image [aspect ratio](https://en.wikipedia.org/wiki/Aspect_ratio_(image)#Still_photography) in the title, e.g. `1:1`, `5:4`, `4:3`, `16:9`, etc.

The function in the PR is mostly taken from [this StackOverflow answer](https://stackoverflow.com/a/43016456/3231411).
It's the best rational approximation algorithm with adjustable level of fuzziness (I used `20`).

Screenshot:
![12345~](https://user-images.githubusercontent.com/723651/119537724-0532f580-bd93-11eb-96c8-4523225e7a9d.gif)

For reference here is an example screenshot of IrfanView  | Image Properties, which provides such info:
![2021-05-25_194136](https://user-images.githubusercontent.com/723651/119536172-72458b80-bd91-11eb-9637-9ca135074bc8.jpg)

I hope you like my suggestion.

