### PR TITLE
Disable built-in VSCode TS-JS syntax validation via workspace settings

### DIFF
--- a/.vscode/.code-workspace
+++ b/.vscode/.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../"
+		}
+	],
+	"settings": {
+		"typescript.validate.enable": false,
+		"javascript.validate.enable": false,
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "typescript.validate.enable": false,
+    "javascript.validate.enable": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "typescript.validate.enable": false,
-    "javascript.validate.enable": false,
+	"typescript.validate.enable": false,
+	"javascript.validate.enable": false,
 }


### PR DESCRIPTION
Following https://github.com/tophf/mpiv/pull/53#discussion_r703427776, I thought of putting those two settings into Workspace settings, to avoid the approach of disabling them globally.

```
    "typescript.validate.enable": false,
    "javascript.validate.enable": false,
```
For reference: [Creating User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings)