### PR TITLE
Update built-in instagram rules after HTML changes

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1988,7 +1988,6 @@ const Ruler = {
         rect: 'div.PhotoGridMediaItem',
         c: text => {
           const isLoggedIn = !!$('svg[aria-label="Home"]');
-          alert(isLoggedIn);
           if (!(isLoggedIn)) {
             const m = JSON.parse(text).graphql.shortcode_media.edge_media_to_caption.edges[0];
             return m === undefined ? '(no caption)' : m.node.text;

--- a/script.user.js
+++ b/script.user.js
@@ -1577,7 +1577,7 @@ const Ruler = {
             a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
             data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
           }
-          const numPics = !(isLoggedIn) ?
+          const numPics = !(isLoggedIn()) ?
             a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
             a && tryCatch(() => data.carousel_media_count);
           Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
@@ -1595,10 +1595,10 @@ const Ruler = {
         follow: true,
         _q: 'meta[property="og:video"]',
         _g(text, doc, url, m, rule) {
-          const media = !(isLoggedIn) ?
+          const media = !(isLoggedIn()) ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
-          const items = !(isLoggedIn) ?
+          const items = !(isLoggedIn()) ?
             media.edge_sidecar_to_children.edges.map(e => ({
               url: e.node.video_url || e.node.display_url,
             })) :
@@ -1610,10 +1610,10 @@ const Ruler = {
           items.title = tryCatch(rule._getCaption, media) || '';
           return items;
         },
-        _getCaption: !(isLoggedIn) ?
+        _getCaption: !(isLoggedIn()) ?
           data => data && data.edge_media_to_caption.edges[0].node.text :
           data => data && data.caption.text,
-        _getEdge:  !(isLoggedIn) ?
+        _getEdge:  !(isLoggedIn()) ?
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
             .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,

--- a/script.user.js
+++ b/script.user.js
@@ -1617,7 +1617,7 @@ const Ruler = {
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
             .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
-      })()),
+      }))(),
       ...dotDomain.endsWith('.reddit.com') && [{
         u: '||i.reddituploads.com/',
       }, {

--- a/script.user.js
+++ b/script.user.js
@@ -1577,7 +1577,7 @@ const Ruler = {
             a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
             data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
           }
-          const numPics = !(isLoggedIn()) ?
+          const numPics = !isLoggedIn() ?
             a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
             a && tryCatch(() => data.carousel_media_count);
           Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
@@ -1595,10 +1595,10 @@ const Ruler = {
         follow: true,
         _q: 'meta[property="og:video"]',
         _g(text, doc, url, m, rule) {
-          const media = !(isLoggedIn()) ?
+          const media = !isLoggedIn() ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
-          const items = !(isLoggedIn()) ?
+          const items = !isLoggedIn() ?
             media.edge_sidecar_to_children.edges.map(e => ({
               url: e.node.video_url || e.node.display_url,
             })) :
@@ -1610,10 +1610,10 @@ const Ruler = {
           items.title = tryCatch(rule._getCaption, media) || '';
           return items;
         },
-        _getCaption: !(isLoggedIn()) ?
+        _getCaption: !isLoggedIn() ?
           data => data && data.edge_media_to_caption.edges[0].node.text :
           data => data && data.caption.text,
-        _getEdge:  !(isLoggedIn()) ?
+        _getEdge:  !isLoggedIn() ?
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
             .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
@@ -1972,10 +1972,10 @@ const Ruler = {
         s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
         q: text => {
           const isLoggedIn = !!$('svg[aria-label="Home"]');
-          const m = !(isLoggedIn) ?
+          const m = !isLoggedIn ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
-          if (!(isLoggedIn)) {
+          if (!isLoggedIn) {
             return m.video_url || m.display_url;
           } else {
             return m.video_versions ?
@@ -1988,7 +1988,7 @@ const Ruler = {
         rect: 'div.PhotoGridMediaItem',
         c: text => {
           const isLoggedIn = !!$('svg[aria-label="Home"]');
-          if (!(isLoggedIn)) {
+          if (!isLoggedIn) {
             const m = JSON.parse(text).graphql.shortcode_media.edge_media_to_caption.edges[0];
             return m === undefined ? '(no caption)' : m.node.text;
           } else {

--- a/script.user.js
+++ b/script.user.js
@@ -1448,6 +1448,8 @@ const Ruler = {
       },
     ];
 
+    const isLoggedIn = !!document.querySelector('svg[aria-label="Home"]');
+
     // optimization: a rule is created only when on domain
     const perDomain = [
       hostname.includes('startpage') && {
@@ -1576,7 +1578,9 @@ const Ruler = {
             a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
             data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
           }
-          const numPics = a && tryCatch(() => data.carousel_media_count);
+          const numPics = !(isLoggedIn) ?
+            a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
+            a && tryCatch(() => data.carousel_media_count);
           Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
           Ruler.toggle(rule, 'g', a && (numPics > 1 || /<\w+[^>]+carousel/i.test(a.innerHTML)));
           rule.follow = !data && !rule.g;
@@ -1592,15 +1596,25 @@ const Ruler = {
         follow: true,
         _q: 'meta[property="og:video"]',
         _g(text, doc, url, m, rule) {
-          const media = JSON.parse(text).items[0];
-          const items = media.carousel_media.map(e => ({
-            url: e.video_versions ? e.video_versions[0].url : e.image_versions2.candidates[0].url,
-          }));
+          const media = !(isLoggedIn) ?
+            JSON.parse(text).graphql.shortcode_media :
+            JSON.parse(text).items[0];
+          const items = !(isLoggedIn) ?
+            media.edge_sidecar_to_children.edges.map(e => ({
+              url: e.node.video_url || e.node.display_url,
+            })) :
+            media.carousel_media.map(e => ({
+              url: e.video_versions ? e.video_versions[0].url : e.image_versions2.candidates[0].url,
+            }));
           items.title = tryCatch(rule._getCaption, media) || '';
           return items;
         },
-        _getCaption: data => data && data.caption.text,
-        _getEdge: shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
+        _getCaption: !(isLoggedIn) ?
+          data => data && data.edge_media_to_caption.edges[0].node.text :
+          data => data && data.caption.text,
+        _getEdge:  !(isLoggedIn) ?
+          shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
+          shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
             .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
       },
       ...dotDomain.endsWith('.reddit.com') && [{
@@ -1956,15 +1970,28 @@ const Ruler = {
         ],
         s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
         q: text => {
-          const m = JSON.parse(text).items[0];
-          return m.video_versions ? m.video_versions[0].url
-            : m.carousel_media ? m.carousel_media[0].image_versions2.candidates[0].url
-              : m.image_versions2.candidates[0].url;
+          const m = !(isLoggedIn) ?
+            JSON.parse(text).graphql.shortcode_media :
+            JSON.parse(text).items[0];
+          if (!(isLoggedIn)) {
+            return m.video_url || m.display_url;
+          } else {
+            return m.video_versions ?
+              m.video_versions[0].url :
+              m.carousel_media ?
+                m.carousel_media[0].image_versions2.candidates[0].url :
+                m.image_versions2.candidates[0].url;
+          }
         },
         rect: 'div.PhotoGridMediaItem',
         c: text => {
-          const m = JSON.parse(text).items[0].caption;
-          return m === undefined ? '(no caption)' : m.text;
+          if (!(isLoggedIn)) {
+            const m = JSON.parse(text).graphql.shortcode_media.edge_media_to_caption.edges[0];
+            return m === undefined ? '(no caption)' : m.node.text;
+          } else {
+            const m = JSON.parse(text).items[0].caption;
+            return m === undefined ? '(no caption)' : m.text;
+          }
         },
       },
       {

--- a/script.user.js
+++ b/script.user.js
@@ -1448,8 +1448,6 @@ const Ruler = {
       },
     ];
 
-    const isLoggedIn = !!document.querySelector('svg[aria-label="Home"]');
-
     // optimization: a rule is created only when on domain
     const perDomain = [
       hostname.includes('startpage') && {
@@ -1563,60 +1561,63 @@ const Ruler = {
           a2.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}));
         },
       },
-      dotDomain.endsWith('.instagram.com') && {
-        e: 'a[href*="/p/"],' +
-          'article [role="button"][tabindex="0"],' +
-          'article [role="button"][tabindex="0"] div',
-        s: (m, node, rule) => {
-          let data, a, n, img, src;
-          if (location.pathname.startsWith('/p/')) {
-            img = $('img[srcset], video', node.parentNode);
-            if (img && (img.localName === 'video' || parseFloat(img.sizes) > 900))
-              src = (img.srcset || img.currentSrc).split(',').pop().split(' ')[0];
-          }
-          if (!src && (n = node.closest('a[href*="/p/"], article'))) {
-            a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
-            data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
-          }
-          const numPics = !(isLoggedIn) ?
-            a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
-            a && tryCatch(() => data.carousel_media_count);
-          Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
-          Ruler.toggle(rule, 'g', a && (numPics > 1 || /<\w+[^>]+carousel/i.test(a.innerHTML)));
-          rule.follow = !data && !rule.g;
-          rule._data = data;
-          rule._img = img;
-          return (
-            !a && !src ? false :
-              !data || rule.q || rule.g ? `${src || a.href}${rule.g ? '?__a=1' : ''}` :
-                data.video_url || data.display_url);
-        },
-        c: (html, doc, node, rule) =>
-          tryCatch(rule._getCaption, rule._data) || (rule._img || 0).alt || '',
-        follow: true,
-        _q: 'meta[property="og:video"]',
-        _g(text, doc, url, m, rule) {
-          const media = !(isLoggedIn) ?
-            JSON.parse(text).graphql.shortcode_media :
-            JSON.parse(text).items[0];
-          const items = !(isLoggedIn) ?
-            media.edge_sidecar_to_children.edges.map(e => ({
-              url: e.node.video_url || e.node.display_url,
-            })) :
-            media.carousel_media.map(e => ({
-              url: e.video_versions ? e.video_versions[0].url : e.image_versions2.candidates[0].url,
-            }));
-          items.title = tryCatch(rule._getCaption, media) || '';
-          return items;
-        },
-        _getCaption: !(isLoggedIn) ?
-          data => data && data.edge_media_to_caption.edges[0].node.text :
-          data => data && data.caption.text,
-        _getEdge:  !(isLoggedIn) ?
-          shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
-          shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
-            .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
-      },
+      dotDomain.endsWith('.instagram.com') &&
+        ((isLoggedIn = () => !!$('svg[aria-label="Home"]')) => ({
+          e: 'a[href*="/p/"],' +
+            'article [role="button"][tabindex="0"],' +
+            'article [role="button"][tabindex="0"] div',
+          s: (m, node, rule) => {
+            let data, a, n, img, src;
+            if (location.pathname.startsWith('/p/')) {
+              img = $('img[srcset], video', node.parentNode);
+              if (img && (img.localName === 'video' || parseFloat(img.sizes) > 900))
+                src = (img.srcset || img.currentSrc).split(',').pop().split(' ')[0];
+            }
+            if (!src && (n = node.closest('a[href*="/p/"], article'))) {
+              a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
+              data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
+            }
+            const numPics = !(isLoggedIn) ?
+              a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
+              a && tryCatch(() => data.carousel_media_count);
+            Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
+            Ruler.toggle(rule, 'g', a && (numPics > 1 || /<\w+[^>]+carousel/i.test(a.innerHTML)));
+            rule.follow = !data && !rule.g;
+            rule._data = data;
+            rule._img = img;
+            return (
+              !a && !src ? false :
+                !data || rule.q || rule.g ? `${src || a.href}${rule.g ? '?__a=1' : ''}` :
+                  data.video_url || data.display_url);
+          },
+          c: (html, doc, node, rule) =>
+            tryCatch(rule._getCaption, rule._data) || (rule._img || 0).alt || '',
+          follow: true,
+          _q: 'meta[property="og:video"]',
+          _g(text, doc, url, m, rule) {
+            const media = !(isLoggedIn) ?
+              JSON.parse(text).graphql.shortcode_media :
+              JSON.parse(text).items[0];
+            const items = !(isLoggedIn) ?
+              media.edge_sidecar_to_children.edges.map(e => ({
+                url: e.node.video_url || e.node.display_url,
+              })) :
+              media.carousel_media.map(e => ({
+                url: e.video_versions ?
+                  e.video_versions[0].url :
+                  e.image_versions2.candidates[0].url,
+              }));
+            items.title = tryCatch(rule._getCaption, media) || '';
+            return items;
+          },
+          _getCaption: !(isLoggedIn) ?
+            data => data && data.edge_media_to_caption.edges[0].node.text :
+            data => data && data.caption.text,
+          _getEdge:  !(isLoggedIn) ?
+            shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
+            shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
+              .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
+        })()),
       ...dotDomain.endsWith('.reddit.com') && [{
         u: '||i.reddituploads.com/',
       }, {
@@ -1970,6 +1971,7 @@ const Ruler = {
         ],
         s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
         q: text => {
+          const isLoggedIn = !!$('svg[aria-label="Home"]');
           const m = !(isLoggedIn) ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
@@ -1985,6 +1987,8 @@ const Ruler = {
         },
         rect: 'div.PhotoGridMediaItem',
         c: text => {
+          const isLoggedIn = !!$('svg[aria-label="Home"]');
+          alert(isLoggedIn);
           if (!(isLoggedIn)) {
             const m = JSON.parse(text).graphql.shortcode_media.edge_media_to_caption.edges[0];
             return m === undefined ? '(no caption)' : m.node.text;

--- a/script.user.js
+++ b/script.user.js
@@ -1577,7 +1577,7 @@ const Ruler = {
             a = n.tagName === 'A' ? n : $('a[href*="/p/"]', n);
             data = a && tryCatch(rule._getEdge, a.pathname.split('/')[2]);
           }
-          const numPics = !isLoggedIn() ?
+          const numPics = isLoggedIn() === false ?
             a && tryCatch(() => data.edge_sidecar_to_children.edges.length) :
             a && tryCatch(() => data.carousel_media_count);
           Ruler.toggle(rule, 'q', data && data.is_video && !data.video_url);
@@ -1595,10 +1595,10 @@ const Ruler = {
         follow: true,
         _q: 'meta[property="og:video"]',
         _g(text, doc, url, m, rule) {
-          const media = !isLoggedIn() ?
+          const media = isLoggedIn() === false ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
-          const items = !isLoggedIn() ?
+          const items = isLoggedIn() === false ?
             media.edge_sidecar_to_children.edges.map(e => ({
               url: e.node.video_url || e.node.display_url,
             })) :
@@ -1610,10 +1610,10 @@ const Ruler = {
           items.title = tryCatch(rule._getCaption, media) || '';
           return items;
         },
-        _getCaption: !isLoggedIn() ?
+        _getCaption: isLoggedIn() === false ?
           data => data && data.edge_media_to_caption.edges[0].node.text :
           data => data && data.caption.text,
-        _getEdge:  !isLoggedIn() ?
+        _getEdge: isLoggedIn() === false ?
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].graphql.user :
           shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
             .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
@@ -1972,10 +1972,10 @@ const Ruler = {
         s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
         q: text => {
           const isLoggedIn = !!$('svg[aria-label="Home"]');
-          const m = !isLoggedIn ?
+          const m = isLoggedIn === false ?
             JSON.parse(text).graphql.shortcode_media :
             JSON.parse(text).items[0];
-          if (!isLoggedIn) {
+          if (isLoggedIn === false) {
             return m.video_url || m.display_url;
           } else {
             return m.video_versions ?
@@ -1988,7 +1988,7 @@ const Ruler = {
         rect: 'div.PhotoGridMediaItem',
         c: text => {
           const isLoggedIn = !!$('svg[aria-label="Home"]');
-          if (!isLoggedIn) {
+          if (isLoggedIn === false) {
             const m = JSON.parse(text).graphql.shortcode_media.edge_media_to_caption.edges[0];
             return m === undefined ? '(no caption)' : m.node.text;
           } else {


### PR DESCRIPTION
Hi there @tophf 

I noticed today that due to HTML changes the instagram built-in rules no longer work anywhere, nor in timeline, nor in profiles or posts themselves.
Additionally I gladly see that now 1440p images are available by default (therefore no need for using modified User-Agent, as Image Max URL script/extension does, see #41).

With this PR I made all needed changes in order the built-in rules to work again.

I am aware that you don't have an instagram account to test via the API (`?__a=1` URLs), 
so here are some screenshots from Firefox's JSON viewer while doing various requests with `?__a=1` to help you check my suggested changes.

<details>
<summary>image post</summary>

![2022-01-20_192800](https://user-images.githubusercontent.com/723651/150395250-37f4fad9-ba88-4f7e-ac9c-5b9366ab16de.jpg)

</details>

<details>
<summary>video post</summary>

![2022-01-20_192812](https://user-images.githubusercontent.com/723651/150395291-cc5ff1c9-ebd4-4766-8347-ad293db82ce5.jpg)

</details>

<details>
<summary>carousel image post</summary>

![2022-01-20_192824](https://user-images.githubusercontent.com/723651/150395303-a88a4a73-775f-4587-8d15-06a21c498832.jpg) ![2022-01-20_192838](https://user-images.githubusercontent.com/723651/150395321-37785d28-bc96-420d-b7e1-3d7843dde98e.jpg)

</details>

Lastly, I believe that the [following part](https://github.com/tophf/mpiv/compare/master...darkred:update-instagram-rules?expand=1#diff-41f5db5093bcf3973ef691f0acdfc063afb72dc50ca75b14a738e4b83ca03efdR1603-R1605) is no longer needed or fixable and should be removed.

```js
_getEdge: shortcode => unsafeWindow._sharedData.entry_data.ProfilePage[0].items[0].user
   .edge_owner_to_timeline_media.edges.find(e => e.node.shortcode === shortcode).node,
},
```

Test URL: https://instagram.com/instagram
