### PR TITLE
Enable in the profiles VIDEOS tab

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1563,7 +1563,7 @@ const Ruler = {
           'article [role="button"][tabindex="0"] div',
         s: (m, node, rule) => {
           let data, a, n, img, src;
-          if (location.pathname.startsWith('/p/')) {
+          if (location.pathname.startsWith('/p/') || location.pathname.startsWith('/tv/')) {
             img = $('img[srcset], video', node.parentNode);
             if (img && (img.localName === 'video' || parseFloat(img.sizes) > 900))
               src = (img.srcset || img.currentSrc).split(',').pop().split(' ')[0];
@@ -1955,6 +1955,7 @@ const Ruler = {
         u: [
           '||instagr.am/p/',
           '||instagram.com/p/',
+          '||instagram.com/tv/',
         ],
         s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
         q: m => (m = tryJSON(m)) && (


### PR DESCRIPTION
I've noticed that the script currently doesn't work in the VIDEOS tab of profiles,
![2022-02-07_175825](https://user-images.githubusercontent.com/723651/152824087-96115b45-8483-4e83-829f-64224470566a.jpg)
i.e. posts in e.g. https://www.instagram.com/instagram/channel/ that all include `/tv/` in their URLS, e.g. https://www.instagram.com/tv/CZcTl1BBKA0/ .

With this PR I suggest two minor changes in enable to support posts in this tab.
