### PR TITLE
Update Instagram rule

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1609,7 +1609,7 @@ const Ruler = {
           rule._img = img;
           return (
             !a && !src ? false :
-              !data || rule.q || rule.g ? `${src || a.href}${rule.g ? '?__a=1' : ''}` :
+              !data || rule.q || rule.g ? `${src || a.href}${rule.g ? '?__a=1&__d=dis' : ''}` :
                 data.video_url || data.display_url);
         },
         c: (html, doc, node, rule) =>
@@ -1993,7 +1993,8 @@ const Ruler = {
           '||instagram.com/p/',
           '||instagram.com/tv/',
         ],
-        s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') + '/?__a=1',
+        s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '')
+        + '/?__a=1&__d=dis',
         q: m => (m = tryJSON(m)) && (
           m = pick(m, 'graphql.shortcode_media') || pick(m, 'items[0]') || 0
         ) && (

--- a/script.user.js
+++ b/script.user.js
@@ -1993,8 +1993,8 @@ const Ruler = {
           '||instagram.com/p/',
           '||instagram.com/tv/',
         ],
-        s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '')
-        + '/?__a=1&__d=dis',
+        s: m => m.input.substr(0, m.input.lastIndexOf('/')).replace('/liked_by', '') +
+        '/?__a=1&__d=dis',
         q: m => (m = tryJSON(m)) && (
           m = pick(m, 'graphql.shortcode_media') || pick(m, 'items[0]') || 0
         ) && (


### PR DESCRIPTION
Fixes #99. 

This PR adds the `__d=dis` endpoint to the built-in Instagram rule. Tested it and everything (single/carousel/video/igtv) works fine again.

I found the endpoint in [this SO answer](https://stackoverflow.com/a/72582413/3231411). The endpoint can also be found in the devtools Network tab, as you load IG pages/posts (see screenshot example):
<details>
<summary>Screenshot:</summary>

![2022-06-12_134635](https://user-images.githubusercontent.com/723651/173229547-f6ece520-ffc2-498b-8e10-81502641b307.jpg)
</details>

Note: I split the second line because of the ESLint `max-len: 100` rule.