### PR TITLE
Hide brackets when no prefix is shown

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -3893,7 +3893,7 @@ function createGlobalStyle() {
 #\mpiv-bar.\mpiv-show {
   opacity: 1;
 }
-#\mpiv-bar[data-zoom]::before {
+#\mpiv-bar[data-zoom][data-prefix]::before {
   content: "[" attr(data-prefix) "] ";
   color: gold;
 }


### PR DESCRIPTION
Even when the data-prefix attribute is unset, the gold brackets are shown:
![image](https://github.com/tophf/mpiv/assets/9013284/37de7429-d4ef-4c80-a754-8336fbb2b5dc)

This PR modifies the stylesheet so that if `#mpiv-bar` doesn't have the data-prefix attribute, the prefix content isn't shown. This is consistent with the implementation of the `$dataset()` function, which deletes the data attribute if a nullish value is provided.
![image](https://github.com/tophf/mpiv/assets/9013284/64cfc7e5-3574-4889-9b77-80b8a0f10066)
